### PR TITLE
Updated README Instructions' return statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ export default function myImageLoader({ src, width, quality }) {
         return src;
     }
     if (isLocal) {
-        return `${imageOptimizationApi}/${fullSrc}?${query.toString()}`;
+        return `${imageOptimizationApi}/image/${fullSrc}?${query.toString()}`;
     }
-    return `${imageOptimizationApi}/${src}?${query.toString()}`;
+    return `${imageOptimizationApi}/image/${src}?${query.toString()}`;
 }
 ```
 


### PR DESCRIPTION
When I was using it via self-hosted coolify, I wasn't able to render the image, after re-reading instructions and some searches I found out that the example had "images/" between the two variables. After trying it out, the image got rendered. Hopefully it helps :)