### PR TITLE
feat: image format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The cloud version, with free global CDN and simple pricing available here: https
 - Change the `width` query parameter to see the image resize on the fly.
 - Add the `height` query parameter to see the image crop on the fly.
 - Add the `quality` query parameter to see the image quality change on the fly.
+- Add the `format` query parameter to force a specific output format (e.g. `png`, `jpeg`, `jpg`, `webp`, `avif`).
 
 https://image.coollabs.io/image/https://cdn.coollabs.io/images/image1.jpg?width=500
 
@@ -71,3 +72,4 @@ export default function myImageLoader({ src, width, quality }) {
 - width
 - height
 - quality
+- format — force output format (`png`, `jpeg`, `jpg`, `webp`, `avif`). Invalid values are ignored and the default format negotiation is used.

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -4,8 +4,8 @@ services:
     ports:
       - "8888:8080"
     environment:
-      - IMGPROXY_ENABLE_WEBP_DETECTION=true
-      - IMGPROXY_ENABLE_AVIF_DETECTION=true
+      - IMGPROXY_AUTO_WEBP=true
+      - IMGPROXY_AUTO_AVIF=true
       - IMGPROXY_PREFERRED_FORMATS=webp,avif,jpeg,png,gif
       - IMGPROXY_JPEG_PROGRESSIVE=true
       - IMGPROXY_USE_ETAG=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
   imgproxy:
     image: darthsim/imgproxy
     environment:
-      - IMGPROXY_ENABLE_WEBP_DETECTION=true
-      - IMGPROXY_ENABLE_AVIF_DETECTION=true
+      - IMGPROXY_AUTO_WEBP=true
+      - IMGPROXY_AUTO_AVIF=true
       - IMGPROXY_JPEG_PROGRESSIVE=true
       - IMGPROXY_USE_ETAG=true
     healthcheck:

--- a/index.js
+++ b/index.js
@@ -43,11 +43,15 @@ async function resize(url) {
     const width = url.searchParams.get("width") || 0;
     const height = url.searchParams.get("height") || 0;
     const quality = url.searchParams.get("quality") || 75;
+    const validFormats = new Set(["png", "jpeg", "jpg", "webp", "avif"]);
+    const formatParam = url.searchParams.get("format");
+    const format = validFormats.has(formatParam) ? formatParam : null;
     try {
-        const url = `${imgproxyUrl}/${preset}/resize:fill:${width}:${height}/q:${quality}/plain/${src}`
+        const source = format ? `${src}@${format}` : src;
+        const url = `${imgproxyUrl}/${preset}/resize:fill:${width}:${height}/q:${quality}/plain/${source}`
         const image = await fetch(url, {
             headers: {
-                "Accept": "image/avif,image/webp,image/apng,*/*",
+                "Accept": format ? `image/${format}` : "image/avif,image/webp,image/apng,*/*",
             }
         })
         const headers = new Headers(image.headers);


### PR DESCRIPTION
Some consumers (like `next/og` / `satori`) can't decode webp or avif. This adds a format query param so callers can request a specific output format (e.g. ?format=png). Invalid values are ignored and everything works as before for existing users.

Also updated the deprecated imgproxy env vars in both docker-compose files.